### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ shutdownBT	KEYWORD2
 switchInput	KEYWORD2
 openPhoneVoice	KEYWORD2
 memoryClear	KEYWORD2
-languageSetNumber KEYWORD2
+languageSetNumber	KEYWORD2
 musicTogglePlayPause	KEYWORD2
 musicStop	KEYWORD2
 musicNextTrack	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords